### PR TITLE
build nginx docker image using Github Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - feature/deploy
 
 env:
   # Beware! The last part of this image name is global for your user or organization.
@@ -16,7 +17,7 @@ env:
 jobs:
 
   build:
-    name: Build docker image
+    name: Build and Deploy
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
@@ -50,3 +51,12 @@ jobs:
           docker pull $DOCKER_IMAGE:$DOCKER_IMAGE_VERSION || true
           docker build --cache-from $DOCKER_IMAGE:$DOCKER_IMAGE_VERSION --tag $DOCKER_IMAGE:$DOCKER_IMAGE_VERSION .
           docker push $DOCKER_IMAGE:$DOCKER_IMAGE_VERSION
+
+      - name: Deploy new image on staging server
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          mkdir -p ~/.ssh
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
+          ssh -o StrictHostKeyChecking=no -p 2020 -l deploy sylvia.machine.queer.haus time

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - main
+
+env:
+  # Beware! The last part of this image name is global for your user or organization.
+  # This "docker.pkg.github.com/queerhaus/collective/collective" is exactly the same image as
+  # this "docker.pkg.github.com/queerhaus/foobaroo/collective"
+  # Also keep in mind that with open source public github projects, these images can never be deleted.
+  # https://help.github.com/en/packages/publishing-and-managing-packages/deleting-a-package
+  DOCKER_IMAGE: docker.pkg.github.com/queerhaus/collective/collective
+  DOCKER_IMAGE_VERSION: main
+
+jobs:
+
+  build:
+    name: Build docker image
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 15
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            build-${{ env.cache-name }}-
+            build-
+
+      - name: Install node modules
+        run: npm install
+
+      - name: Build gatsby site
+        run: npm run build
+
+      - name: Build docker image using previous image as cache
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          docker pull $DOCKER_IMAGE:$DOCKER_IMAGE_VERSION || true
+          docker build --cache-from $DOCKER_IMAGE:$DOCKER_IMAGE_VERSION --tag $DOCKER_IMAGE:$DOCKER_IMAGE_VERSION .
+          docker push $DOCKER_IMAGE:$DOCKER_IMAGE_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Taken from: https://github.com/gatsbyjs/gatsby-docker
+FROM alpine:3
+
+COPY docker/nginx-boot.sh /sbin/nginx-boot
+RUN chmod +x /sbin/nginx-boot
+
+RUN apk --update add nginx bash && \
+    rm -fR /var/cache/apk/*
+
+CMD [ "/sbin/nginx-boot" ]
+EXPOSE 80
+
+COPY ./public /pub

--- a/docker/nginx-boot.sh
+++ b/docker/nginx-boot.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Taken from here: https://github.com/gatsbyjs/gatsby-docker/blob/master/nginx-boot.sh
+
+# Check for variables
+export CHARSET=${CHARSET:-utf-8}
+
+export WORKER_CONNECTIONS=${WORKER_CONNECTIONS:-1024}
+export HTTP_PORT=${HTTP_PORT:-80}
+export NGINX_CONF=/etc/nginx/mushed.conf
+
+export PUBLIC_PATH=${PUBLIC_PATH:-/pub}
+
+export GZIP_TYPES=${GZIP_TYPES:-application/javascript application/x-javascript application/rss+xml text/javascript text/css image/svg+xml}
+export GZIP_LEVEL=${GZIP_LEVEL:-6}
+
+export CACHE_IGNORE=${CACHE_IGNORE:-html}
+export CACHE_PUBLIC=${CACHE_PUBLIC:-ico|jpg|jpeg|png|gif|svg|js|jsx|css|less|swf|eot|ttf|otf|woff|woff2}
+export CACHE_PUBLIC_EXPIRATION=${CACHE_PUBLIC_EXPIRATION:-1y}
+
+if [ "$TRAILING_SLASH" = false ]; then
+  REWRITE_RULE="rewrite ^(.+)/+\$ \$1 permanent"
+  TRY_FILES="try_files \$uri \$uri/index.html =404"
+else
+  REWRITE_RULE="rewrite ^([^.]*[^/])\$ \$1/ permanent"
+  TRY_FILES="try_files \$uri \$uri/ \$uri/index.html =404"
+fi
+
+if [ "$DISABLE_FILE_CACHE" != true ]; then
+  read -r -d '' FILE_CACHE <<'EOF'
+  ## Cache open FD
+  open_file_cache max=10000 inactive=3600s;
+  open_file_cache_valid 7200s;
+  open_file_cache_min_uses 2;
+EOF
+fi
+
+if [ -f /etc/nginx/server.conf ]; then
+  CUSTOM_SERVER_CONFIG=$(</etc/nginx/server.conf)
+else
+  CUSTOM_SERVER_CONFIG=${CUSTOM_SERVER_CONFIG:-};
+fi
+
+# Build config
+cat <<EOF > $NGINX_CONF
+daemon              off;
+worker_processes    1;
+user                root;
+events {
+  worker_connections $WORKER_CONNECTIONS;
+}
+http {
+  include       mime.types;
+  default_type  application/octet-stream;
+  keepalive_timeout  15;
+  autoindex          off;
+  server_tokens      off;
+  port_in_redirect   off;
+  absolute_redirect  off;
+  sendfile           off;
+  tcp_nopush         on;
+  tcp_nodelay        on;
+  client_max_body_size 64k;
+  client_header_buffer_size 16k;
+  large_client_header_buffers 4 16k;
+  $FILE_CACHE
+  ## Gzipping is an easy way to reduce page weight
+  gzip                on;
+  gzip_vary           on;
+  gzip_proxied        any;
+  gzip_types          $GZIP_TYPES;
+  gzip_buffers        16 8k;
+  gzip_comp_level     $GZIP_LEVEL;
+  access_log         /dev/stdout;
+  error_log          /dev/stderr error;
+  server {
+    listen $HTTP_PORT;
+    root $PUBLIC_PATH;
+    index index.html;
+    autoindex off;
+    charset $CHARSET;
+    error_page 404 /404.html;
+    location ~* \.($CACHE_IGNORE)$ {
+      add_header Cache-Control "no-store";
+      expires    off;
+    }
+    location ~* \.($CACHE_PUBLIC)$ {
+      add_header Cache-Control "public";
+      expires +$CACHE_PUBLIC_EXPIRATION;
+    }
+    $REWRITE_RULE;
+    $TRY_FILES;
+    $CUSTOM_SERVER_CONFIG
+  }
+}
+EOF
+
+[ "" != "$DEBUG" ] && cat $NGINX_CONF;
+
+mkdir -p /run/nginx/
+chown -R root:root /var/lib/nginx
+
+exec nginx -c $NGINX_CONF


### PR DESCRIPTION
This is a quick setup using the official gatsbyjs docker build as a template, but freezing alpine version and using Github Actions cache instead of building everything inside docker image.

Using the Github Actions nodejs install and cache is much faster than pushing docker images back and forth on Github Actions.